### PR TITLE
Adding 'xhr2' node module to handle XHR with 'arraybuffer' response type

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-var async = require('async');
+var async = require('async'),
+    XMLHttpRequest = require('xhr2').XMLHttpRequest;
 
 function loadBuffers(paths, context, cb) {
   if (Array.isArray(paths)) {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/jergason/webaudio-buffer-loader.git"
   },
   "dependencies": {
-    "async": "0.9.0"
+    "async": "^0.9.0",
+    "xhr2": "^0.1.1"
   }
 }


### PR DESCRIPTION
When I tried to use your library I found you've missed adding an XMLHttpRequest node module to your package.json as well as to your index.js, so I modified it, tested it and it should be fine now.
